### PR TITLE
build-actions 구현

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker 이미지 빌드
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/my-app:${{ github.sha }} .
+
+      - name: Docker Hub에 로그인
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Docker 이미지 푸시
+        run: |
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/my-app:${{ github.sha }}
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/my-app:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/my-app:latest
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/my-app:latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-push  # build-and-push 작업 완료 후 실행
+    steps:
+      - name: SSH into EC2 and setup Docker
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo systemctl start docker
+            sudo systemctl enable docker
+            sudo usermod -aG docker $USER
+            newgrp docker
+
+      - name: SSH into EC2 and run Docker container
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/my-app:latest
+            docker stop my-container || true
+            docker rm my-container || true
+            docker run -d --name my-container -p 3000:3000 ${{ secrets.DOCKERHUB_USERNAME }}/my-app:latest

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,23 @@
+# Node.js 런타임 이미지를 베이스로 생성
+FROM node:18-alpine
+
+# 컨테이너 내의 작업 디렉토리를 설정
+WORKDIR /app
+
+# package.json과 package-lock.json을 작업 디렉토리에 복사 (분리하여 캐싱 활용)
+COPY package*.json ./
+
+# 애플리케이션 의존성 설치
+RUN npm install --omit=dev  # 프로덕션 환경에서는 devDependencies 제외
+
+# 나머지 애플리케이션 코드 복사
+COPY . ./
+
+# 애플리케이션 빌드
+RUN npm run build
+
+# 앱이 실행될 포트 노출
+EXPOSE 3000
+
+# 애플리케이션 시작
+CMD [ "npm", "start" ]


### PR DESCRIPTION
# PR
build-actions 구현

## PR 요약
GitHub Actions가 Docker 이미지를 빌드 → Docker Hub에 푸시 → EC2 서버에 SSH로 접속하여 최신 이미지를 가져와 컨테이너를 재배포 구현

## 변경된 점

## 이슈 번호
#19